### PR TITLE
Update parse.js to default to using 'content' attribute value for undefined elements

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -123,8 +123,9 @@ function parse ($, $nodes, config) {
     } else if ($node.is('time')) {
       return resolveAttribute($node, 'datetime');
     } else {
+      var content = resolveAttribute($node, 'content');
       var text = $node.text();
-      return text || '';
+      return content|| text || '';
     }
   }
 


### PR DESCRIPTION
In most cases microdata elements (especially div's) will use the content attribute to define the content which is usually formatted in a much more usable way that the text. 

I think it makes sense to use the content attribute first, then text if it's undefined.